### PR TITLE
NOT FOR MERGE: getting to to compile with opencilk

### DIFF
--- a/Semirings.h
+++ b/Semirings.h
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cmath>
 #include <tr1/array>
+#include <memory>
 #include "promote.h"
 
 template <typename T>
@@ -60,7 +61,7 @@ struct UnrollerL {
 template<int End, int Step>
 struct UnrollerL<End, End, Step> {
     template<typename Lambda>
-    static void step(Lambda& func) {
+    [[maybe_unused]] static void step([[maybe_unused]] Lambda& func) {
 		// base case is when Begin=End; do nothing
     }
 };
@@ -75,13 +76,13 @@ struct PTSRArray
 	// y <- a*x + y overload with a=1
 	static void axpy(const array<T2, D> & b, array<T_promote, D> & c)
 	{
+		// const T2 * __restrict barr =  std::assume_aligned<ALIGN>(b.data());
+		// T_promote * __restrict carr = std::assume_aligned<ALIGN>(c.data());
 		const T2 * __restrict barr =  b.data();
 		T_promote * __restrict carr = c.data();
-		__assume_aligned(barr, ALIGN);
-		__assume_aligned(carr, ALIGN);
 
 		#pragma simd
-		for(int i=0; i<D; ++i)
+		for(unsigned int i=0; i<D; ++i)
 		{
 			carr[i] +=  barr[i];
 		}
@@ -92,13 +93,13 @@ struct PTSRArray
 	// Todo: Do partial unrolling; this code will bloat for D > 32 
 	static void axpy(T1 a, const array<T2,D> & b, array<T_promote,D> & c)
 	{
+		// const T2 * __restrict barr =  std::assume_aligned<ALIGN>(b.data());
+		// T_promote * __restrict carr = std::assume_aligned<ALIGN>(c.data());
 		const T2 * __restrict barr =  b.data();
 		T_promote * __restrict carr = c.data();
-		__assume_aligned(barr, ALIGN);
-		__assume_aligned(carr, ALIGN);
 
 		#pragma simd
-		for(int i=0; i<D; ++i)
+		for(unsigned int i=0; i<D; ++i)
 		{
 			carr[i] +=  a* barr[i];
 		}	

--- a/aligned.h
+++ b/aligned.h
@@ -2,6 +2,7 @@
 #include <malloc.h>
 #endif
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 #include <iostream>
 using namespace std;
@@ -71,7 +72,7 @@ class aligned_allocator
 		// Returns true if and only if storage allocated from *this
 		// can be deallocated from other, and vice versa.
 		// Always returns true for stateless allocators.
-		bool operator==(const aligned_allocator& other) const
+		bool operator==([[maybe_unused]] const aligned_allocator& other) const
 		{
 			return true;
 		}
@@ -110,7 +111,7 @@ class aligned_allocator
 			}
  
 			// Mallocator wraps malloc().
-			void * const pv = _mm_malloc(n * sizeof(T), Alignment);
+			void * const pv = std::aligned_alloc(Alignment, n * sizeof(T));
  
 			// Allocators should throw std::bad_alloc in the case of memory allocation failure.
 			if (pv == NULL)
@@ -121,9 +122,9 @@ class aligned_allocator
 			return static_cast<T *>(pv);
 		}
  
-		void deallocate(T * const p, const std::size_t n) const
+		void deallocate(T * const p, [[maybe_unused]] const std::size_t n) const
 		{
-			_mm_free(p);
+			free(p);
 		}
  
  

--- a/bicsb.cpp
+++ b/bicsb.cpp
@@ -20,8 +20,8 @@ void BiCsb<NT, IT>::Init(int workers, IT forcelogbeta)
 	bool sizereq;
 	if (ispar)
 	{
-		sizereq = ((IntPower<2>(rowbits) > SLACKNESS * workers) 
-			&& (IntPower<2>(colbits) > SLACKNESS * workers));
+		sizereq = ((IntPower<2>(rowbits) > (unsigned int) SLACKNESS * workers) 
+			&& (IntPower<2>(colbits) > (unsigned int) SLACKNESS * workers));
 	}
 	else
 	{
@@ -43,7 +43,7 @@ void BiCsb<NT, IT>::Init(int workers, IT forcelogbeta)
 	colhighbits = colbits-collowbits;	// # higher order bits for cols (has at least one bit)
 	if(ispar)
 	{
-		while(IntPower<2>(rowhighbits) < SLACKNESS * workers)
+		while(IntPower<2>(rowhighbits) < (unsigned int) SLACKNESS * workers)
 		{
 			rowhighbits++;
 			rowlowbits--;
@@ -869,8 +869,8 @@ void BiCsb<NT, IT>::SubSpMV(IT * __restrict btop, IT bstart, IT bend, const RHS 
 	IT * __restrict r_bot = bot;
 	NT * __restrict r_num = num;
 
-	__m128i lcms = _mm_set1_epi32 (lowcolmask);
-	__m128i lrms = _mm_set1_epi32 (lowrowmask);
+	[[maybe_unused]] __m128i lcms = _mm_set1_epi32 (lowcolmask);
+	[[maybe_unused]] __m128i lrms = _mm_set1_epi32 (lowrowmask);
 
 	for (IT j = bstart ; j < bend ; ++j)		// for all blocks inside that block row
 	{
@@ -1350,8 +1350,9 @@ ofstream & BiCsb<NT, IT>::PrintStats(ofstream & outfile) const
 	outfile << "## Number of real blocks is "<< ntop << endl;
 	outfile << "## Row imbalance is " << RowImbalance(*this) << endl;
 	outfile << "## Col imbalance is " << ColImbalance(*this) << endl;
+	#ifdef STATS
 	outfile << "## Block parallel calls is " << blockparcalls.get_value() << endl;
-	
+	#endif
 	std::vector<int> blocksizes(ntop);
 	for(IT i=0; i<nbr; ++i)
 	{

--- a/bmcsb.h
+++ b/bmcsb.h
@@ -31,6 +31,7 @@ public:
 	ofstream & PrintStats(ofstream & outfile) const;
 	IT colsize() const { return n;} 
 	IT rowsize() const { return m;} 
+	IT numnonzeros() const { return nz; }
 	IT numregb() const { return nrb;}
 	bool isPar() const { return ispar; }
 

--- a/both_test.cpp
+++ b/both_test.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-#ifndef CILK_STUB
+#if CILK==1
 	int gl_nworkers = __cilkrts_get_nworkers();
 #else
 	int gl_nworkers = 0;

--- a/csb_spmv_test.cpp
+++ b/csb_spmv_test.cpp
@@ -12,6 +12,11 @@
 #include "cilk_util.h"
 #include "utility.h"
 
+#ifndef RHSDIM
+	#define RHSDIM 16
+#endif
+#define ALIGN 32
+
 #include "triple.h"
 #include "csc.h"
 #include "bicsb.h"
@@ -32,7 +37,7 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-#ifndef CILK_STUB
+#if CILK==1
 	int gl_nworkers = __cilkrts_get_nworkers();
 #else
 	int gl_nworkers = 0;

--- a/csb_spmvt_test.cpp
+++ b/csb_spmvt_test.cpp
@@ -30,7 +30,7 @@ INDEXTYPE flops;
 
 int main(int argc, char* argv[])
 {
-#ifndef	CILK_STUB
+#if CILK==1
 	int gl_nworkers = __cilkrts_get_nworkers();
 #else
 	int gl_nworkers = 0;

--- a/csc.cpp
+++ b/csc.cpp
@@ -98,7 +98,7 @@ Csc<T,ITYPE>::~Csc()
 // (a) triples only contain the upper triangular part, or (b) the whole matrix
 template <class T, class ITYPE>
 Csc<T,ITYPE>::Csc(Triple<T, ITYPE> * triples, ITYPE size, ITYPE rows, ITYPE cols, bool isSym)
-:nz(size),m(rows),n(cols),issym(isSym)
+:issym(isSym), nz(size),m(rows),n(cols)
 {
 	// Constructing empty Csc objects (size = 0) are not allowed.
 	assert(size != 0 && n != 0);
@@ -174,7 +174,7 @@ Csc<T,ITYPE>::Csc(Triple<T, ITYPE> * triples, ITYPE size, ITYPE rows, ITYPE cols
 // Construct a Csc object from parallel arrays
 template <class T, class ITYPE>
 Csc<T,ITYPE>::Csc(ITYPE * ri, ITYPE * ci, T * val, ITYPE size, ITYPE rows, ITYPE cols, bool isSym)
-:nz(size),m(rows),n(cols),issym(isSym)
+:issym(isSym),nz(size),m(rows),n(cols)
 {
 	// Constructing empty Csc objects (size = 0) are not allowed.
 	assert(size != 0 && n != 0);

--- a/csc.h
+++ b/csc.h
@@ -15,7 +15,7 @@ template <class T, class ITYPE>
 class Csc
 {
 public:
-	Csc ():nz(0), m(0), n(0), logicalnz(0), issym(false) {}				// default constructor
+	Csc (): issym(false), logicalnz(0), nz(0), m(0), n(0) {}				// default constructor
 	Csc (ITYPE size,ITYPE rows, ITYPE cols, bool isSym=false);
 	Csc (const Csc<T, ITYPE> & rhs);		// copy constructor
 	~Csc();

--- a/friends.h
+++ b/friends.h
@@ -35,7 +35,7 @@ void bmcsb_gespmv (const BmCsb<NT, IT, TTDIM> & A, const NT * __restrict x, NT *
 	double t0 = timer_seconds_since_init();
 	
 	unsigned * scansum = new unsigned[A.nrb];
-	unsigned sum = prescan(scansum, A.masks, A.nrb);
+	[[maybe_unused]] unsigned sum = prescan(scansum, A.masks, A.nrb);
 	
 	double t1 = timer_seconds_since_init();
 	prescantime += (t1-t0);
@@ -128,14 +128,15 @@ void bicsb_gespmv (const BiCsb<NT, IT> & A, const RHS * __restrict x, LHS * __re
 				IT thsh = BREAKEVEN * ysize;
 				vector<IT*> chunks;
 				chunks.push_back(btop);
-				for(IT j =0; j < A.nbc; )
+				for(IT j =0; j < A.nbc-1; )
 				{
 					IT count = btop[j+1] - btop[j];
 					if(count < thsh && j < A.nbc)
 					{
-						while(count < thsh && j < A.nbc)
+						while(count < thsh && j < A.nbc-1)
 						{
-							count += btop[(++j)+1] - btop[j]; 
+							j+=1;
+							count += btop[j+1] - btop[j]; 
 						}
 						chunks.push_back(btop+j);	// push, but exclude the block that caused the overflow
 					}

--- a/spmm_test.cpp
+++ b/spmm_test.cpp
@@ -105,12 +105,12 @@ void VerifyMM (vector< array<NT,DIM>, ALLOC > & control, vector< array<NT,DIM>, 
 
 int main(int argc, char* argv[])
 {
-#ifndef CILK_STUB
+#if CILK==1
 	int gl_nworkers = __cilkrts_get_nworkers();
 #else
 	int gl_nworkers = 0;
 #endif
-	bool syminput = false;
+	[[maybe_unused]] bool syminput = false;
 	bool binary = false;
 	bool iscsc = false;
 	INDEXTYPE m = 0, n = 0, nnz = 0, forcelogbeta = 0;

--- a/spvec.cpp
+++ b/spvec.cpp
@@ -141,7 +141,7 @@ void Spvec<T,ITYPE>::fillzero()
 }
 
 template <typename NT, typename IT>
-void Verify(Spvec<NT, IT> & control, Spvec<NT, IT> & test, string name, IT m)
+void Verify(Spvec<NT, IT> & control, Spvec<NT, IT> & test, [[maybe_unused]] string name, IT m)
 {
     vector<NT>error(m);
     std::transform(&control[0], (&control[0])+m, &test[0], error.begin(), absdiff<NT>());

--- a/sym_spmv_test.cpp
+++ b/sym_spmv_test.cpp
@@ -10,7 +10,11 @@
 
 #include "utility"
 #include "timer.gettimeofday.c"
-#include "cilk_util.h"
+
+#ifndef RHSDIM
+	#define RHSDIM 16
+#endif
+#define ALIGN 32
 
 #include "triple.h"
 #include "csc.h"
@@ -33,7 +37,7 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-#ifndef CILK_STUB
+#if CILK==1
 	int gl_nworkers = WORKERS;
 #else
 	int gl_nworkers = 0;
@@ -110,7 +114,7 @@ int main(int argc, char* argv[])
 			return 1;		
 		}
 
-		long tstart = cilk_get_time();	// start timer
+		long tstart = get_time();	// start timer
 		cout << "Reading matrix with dimensions: "<< m << "-by-" << n <<" having "<< nnz << " nonzeros" << endl;
 		
 		INDEXTYPE * rowindices = new INDEXTYPE[nnz];
@@ -127,7 +131,7 @@ int main(int argc, char* argv[])
 			return -1;
 		}
 
-		long tend = cilk_get_time();	// end timer	
+		long tend = get_time();	// end timer	
 		cout<< "Reading matrix in binary took " << ((VALUETYPE) (tend-tstart)) /1000 << " seconds" <<endl;
 		fclose(f);
 		
@@ -152,7 +156,7 @@ int main(int argc, char* argv[])
 		infile.unget();
 		infile >> m >> n >> nnz;	// #{rows}-#{cols}-#{nonzeros}
 
-		long tstart = cilk_get_time();	// start timer	
+		long tstart = get_time();	// start timer	
 		Triple<VALUETYPE, INDEXTYPE> * triples = new Triple<VALUETYPE, INDEXTYPE>[nnz];
 	
 		if (infile.is_open())
@@ -167,7 +171,7 @@ int main(int argc, char* argv[])
 			}
 			assert(cnz == nnz);	
 		}
-		long tend = cilk_get_time();	// end timer	
+		long tend = get_time();	// end timer	
 		cout<< "Reading matrix in ascii took " << ((double) (tend-tstart)) /1000 << " seconds" <<endl;
 	
 		cout << "converting to csc ... " << endl;

--- a/utility.h
+++ b/utility.h
@@ -16,12 +16,21 @@
 
 using namespace std;
 
+#if CILK==1
 #include <cilk/cilk_api.h>
 #include <cilk/cilk.h>
 #define SYNCHED __cilkrts_synched()
 #define DETECT __cilkscreen_enable_checking()
 #define ENDDETECT __cilkscreen_disable_checking()
 #define WORKERS __cilkrts_get_nworkers()
+#else
+#define cilk_for for
+#define cilk_sync
+#define cilk_spawn 
+#define SYNCHED (true)
+#define WORKERS (1)
+#endif
+
 
 #ifdef BWTEST
 	#define UNROLL 100
@@ -29,7 +38,7 @@ using namespace std;
 	#define UNROLL 1
 #endif
 
-#ifndef CILK_STUB
+#if CILK==1
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,16 +50,15 @@ extern "C" {
  * full frame to determine this.
  */
 
-CILK_EXPORT __CILKRTS_NOTHROW
-int __cilkrts_synched(void);
+#define __cilkrts_synched() (0)
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
-#else /* CILK_STUB */
+#else /* CILK==1 */
 /* Stubs for the api functions */
 #define __cilkrts_synched() (1)
-#endif /* CILK_STUB */
+#endif /* CILK */
 
 #ifdef STATS
 	#include <cilk/reducer_opadd.h>
@@ -96,7 +104,7 @@ const unsigned char masktable4[4] = { 0x08, 0x04, 0x02, 0x01 };	// mask for 2x2 
 
 
 template <typename MTYPE>
-MTYPE GetMaskTable(unsigned int index)
+MTYPE GetMaskTable([[maybe_unused]] unsigned int index)
 {
 	return 0;
 } 
@@ -501,6 +509,12 @@ inline unsigned int getDivident(unsigned int n, unsigned int d)
 	while((d = d >> 1))
 		n = n >> 1;
 	return n;
+}
+
+[[maybe_unused]] static long get_time() {
+  struct timeval st;
+  gettimeofday(&st, NULL);
+  return st.tv_sec * 1000000 + st.tv_usec;
 }
 
 #endif


### PR DESCRIPTION
I took a stab at converting this use opencilk.
It now has some makefile flags which allow you to flip between a serial version, a cilk version, and an openmp version.

I did run into some issues with the code not compiling for what looked to be unrelated reasons like not defining functions, or having includes in the wrong order.  

I also didn't have any test files so I could only ensure that the code compiled, not that it ran correctly, but the main base of converting to using modern cilk should be done.